### PR TITLE
Refactoring of conan infra

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ This repository contains conan package files (http://conan.io) for Greenplum  de
 
 Each dependency should be tracked by recipes in their own directory and each version should have it's own recipe file.  As a dependency is rev'd to a new version, a new recipe file should be added.
 
+## Installing Conan
+
+```
+        pip install conan
+```
+
 ## Hosting Packages
 
 We are hosting the packages in a [Bintray](http:bintray.com) repository.  If you want to simply consume packages then you only need to update your list of remotes via the command:
@@ -17,5 +23,39 @@ We are hosting the packages in a [Bintray](http:bintray.com) repository.  If you
 If you wish to contribute packages or update, please create a user on Bintray and request membership to the **greenplum-db** organization
 
 ## Creating Packages
+
+### Registration (If not registered with bintray)
+
+  1. Register at https://bintray.com/signup, use `Signup with Github`.
+     * Authorize bintray
+     * Set Organization Id to your preferred name
+     * Chose Country
+     * Complete Registration
+  2. Once logged in, go to https://bintray.com/greenplum-db and Click `Join`.
+  3. Once logged in, go to `Edit Profile` -> `API Key` -> `Show`. This will be your password to upload packages to bintray.
+
+### Build and Publish packages
+  1. Clone conan repostiory into your local workspace 
+     * `git clone git@github.com:greenplum-db/conan.git`
+  2. Go to the conan repository directory in your local workspace
+     * `cd conan`
+  3. Add conan remote repository
+     * `conan remote add <REMOTE_NAME> https://api.bintray.com/conan/greenplum-db/gpdb-oss`
+  4. Build `ORCA` or `XERCES-C` (For now xerces-c is stable and no changes are being pushed in, so you may not need to build xerces-c). If building gpxerces, replace orca/<orca_version> with xerces-c/<xerces_version> in the commands below.
+     * Update orca_version in orca_build_environ_vars.sh.
+     * `source orca_build_environ_vars.sh`
+       * It will export orca_version and gpxerces_version environment variables used by conan
+     * `cd orca`
+     * `conan export gpdb/stable`
+       * It will cache the local conanfile.py present in the current directory
+     * `conan install orca/v2.40.2@gpdb/stable --build=missing`
+       * It will build orca v2.40.2 package
+       * Replace v2.40.2 with the version you want to build
+       * By default, build_type is Release. To set build_type to debug, you can execute `conan install -s build_type=Debug  orca/v2.40.2@gpdb/stable --build`
+     * `conan user -p "<API KEY>" --remote <REMOTE_NAME> <GITHUB_USER_NAME>`
+       * It will set the credentials used to publish the packages to bintray. 
+       * Ex: conan user -p "c5aaasdfasdfasdfasdfadsfasc6386afe7028f0579c1" --remote conan-gpdb bhuvnesh2703
+     * `conan upload orca/v2.40.2@gpdb/stable --all -r=<REMOTE_NAME>`
+       * It will upload the v2.40.2 orca package to bintray
 
 A tutorial and further instructions on how to write packages can be found at the [Conan site](http://conanio.readthedocs.io/en/latest/).  Further help can be found either on the [Conan github](https://github.com/conan-io/conan) or on the [Greenplum Mailinglist](gpdb-dev@greenplum.org)

--- a/orca_build_environ_vars.sh
+++ b/orca_build_environ_vars.sh
@@ -1,0 +1,2 @@
+export xerces_version="Xerces-C_3_1_2"
+export orca_version="v2.40.2"

--- a/xerces-c/conanfile.py
+++ b/xerces-c/conanfile.py
@@ -1,18 +1,19 @@
 from conans import ConanFile, AutoToolsBuildEnvironment, tools
 import os
 
-
 class GpxercesConan(ConanFile):
-    name = "gpxerces"
-    version = "v3.1.2-p1"
+    name = "xerces-c"
+    version = os.getenv("xerces_version")
     license = "Apache License v2.0"
-    url = "http://github.com/greenplum-db/conan"
+    url = os.getenv("conan_github_url")
     settings = "os", "compiler", "build_type", "arch"
     options = {"shared": [True, False]}
     default_options = "shared=True"
 
     def source(self):
-        self.run("git clone -b v3.1.2-p1 https://github.com/greenplum-db/gp-xerces.git")
+        self.run("git clone -b {0} https://github.com/apache/xerces-c.git".format(self.version))
+        self.run("cd xerces-c && ./reconf")
+
 
     def build(self):
         env_build = AutoToolsBuildEnvironment(self)
@@ -22,7 +23,7 @@ class GpxercesConan(ConanFile):
             if not self.options.shared:
                 config_args.append("--enable-shared")
             config_args.append("--prefix=" + self.build_folder + "/install")
-            env_build.configure(configure_dir="../gp-xerces/", args=config_args)
+            env_build.configure(configure_dir="../xerces-c/", args=config_args)
             env_build.make()
             env_build.make(args=["install"])
 


### PR DESCRIPTION
Refactored conan scripts with the following:
* Instead of creating or replacing the version number in orca .py files, export the variable or source the *vars.sh file and Made the files default name to conanfile.py
* Instead of using patched xerces, use open source xerces 3.1.2
* Removed unused parameter shared
* Added documentations with steps to register, build and upload packages
* Fixed Linter warnings